### PR TITLE
Add notes for the dealer/rep

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ socket.frames.listen((frame) {
 });
 ```
 
-> NOTE: There're only ASYNC methods above to use. If you're trying to use req/rep pattern, consider using `SocketType.dealer` instead. Therefore you need to add an empty ZFrame at the beginning of your ZMessage as identification.
 
 Receive payloads (`Uint8List`)
 ```dart
@@ -70,6 +69,7 @@ socket.payloads.listen((payload) {
 });
 ```
 
+> NOTE: There're only ASYNC methods above to use. If you're trying to use req/rep pattern, consider using `SocketType.dealer` instead. Therefore you need to add an empty ZFrame at the beginning of your ZMessage as identification.
 Receive socket events
 ```dart
 final MonitoredZSocket socket = context.createMonitoredSocket(SocketType.req);

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ socket.frames.listen((frame) {
 });
 ```
 
+> NOTE: There're only ASYNC methods above to use. If you're trying to use req/rep pattern, consider using `SocketType.dealer` instead. Therefore you need to add an empty ZFrame at the beginning of your ZMessage as identification.
+
 Receive payloads (`Uint8List`)
 ```dart
 socket.payloads.listen((payload) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -82,6 +82,10 @@ class _MyHomePageState extends State<MyHomePage> {
   void _sendMessage() {
     ++_presses;
     _socket.send([_presses], nowait: true);
+    // NOTE: if you're using dealer/rep, an empty message for identification is required.
+    // newMessage.add(ZFrame(Uint8List(0)));
+    // newMessage.add(ZFrame(Uint8List.fromList([_presses])));
+    // _socket.sendMessage(newMessage, nowait: true);
   }
 
   @override


### PR DESCRIPTION
There's no sync methods for simple req/rep, and async methods are always throwing exceptions. If simply change req to dealer, the `send` method only work for router, but not rep. So I added notes for the dealer/rep pattern how to correctly use the send and listen methods. Working well. Tested by myself.